### PR TITLE
Use latest version of protoc

### DIFF
--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -173,7 +173,7 @@ object ProtocPlugin extends AutoPlugin {
 
   private[this] def protobufGlobalSettings: Seq[Def.Setting[_]] =
     Seq(
-      PB.protocVersion            := "3.15.6",
+      PB.protocVersion            := "3.18.1",
       PB.deleteTargetDirectory    := true,
       PB.cacheArtifactResolution  := true,
       PB.cacheClassLoaders        := true,


### PR DESCRIPTION
* versions from 3.17.3 upwards support the Mac M1 architecture (osx-aarch_64), and allow native usage of sbt on a Mac M1, see https://github.com/protocolbuffers/protobuf/pull/8557